### PR TITLE
Add support for SeekPosition, needed for CSV Handling

### DIFF
--- a/src/cwiqduck_extension.cpp
+++ b/src/cwiqduck_extension.cpp
@@ -20,13 +20,20 @@
 
 namespace duckdb {
 
-// Lazy-load the actual S3 handle when needed
+S3RedirectFileHandle::S3RedirectFileHandle(FileSystem &fs, DatabaseInstance &db, const string &url,
+                                           idx_t content_length, timestamp_t last_modified,
+                                           optional_ptr<FileOpener> opener)
+    : FileHandle(fs, url, FileFlags::FILE_FLAGS_READ), s3_url(url), known_content_length(content_length),
+      last_modified_time(last_modified), db_instance(db) {
+	// Open eagerly while opener is in scope (credentials are read at OpenFile time by httpfs).
+	// FILE_FLAGS_PARALLEL_ACCESS tells httpfs to bypass its shared rolling buffer and use per-range
+	// GET requests protected by hfh.mu, making concurrent positional reads safe on this handle.
+	auto &main_fs = FileSystem::GetFileSystem(db);
+	s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+}
+
 FileHandle &S3RedirectFileHandle::GetS3Handle() {
-	if (!s3_handle) {
-		// Let DuckDB's httpfs handle the S3 URL
-		auto &main_fs = FileSystem::GetFileSystem(db_instance);
-		s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ, nullptr);
-	}
+	D_ASSERT(s3_handle);
 	return *s3_handle;
 }
 
@@ -131,6 +138,14 @@ void S3RedirectProtocolFileSystem::Seek(FileHandle &handle, idx_t location) {
 	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
 	if (s3_handle) {
 		return s3_handle->GetS3Handle().Seek(location);
+	}
+	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
+}
+
+idx_t S3RedirectProtocolFileSystem::SeekPosition(FileHandle &handle) {
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->GetS3Handle().SeekPosition();
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }

--- a/src/cwiqduck_extension.cpp
+++ b/src/cwiqduck_extension.cpp
@@ -25,32 +25,62 @@
 
 namespace duckdb {
 
+// ---------------------------------------------------------------------------
+// S3RedirectFileHandle — pool internals
+// ---------------------------------------------------------------------------
+
+unique_ptr<FileHandle> S3RedirectFileHandle::OpenHandle() const {
+	// Plain read flags: correctness comes from the pool's exclusive-ownership model
+	// (no two threads share a handle's mutable state), not from any httpfs-internal flag.
+	auto flags = FileFlags::FILE_FLAGS_READ;
+	auto &main_fs = FileSystem::GetFileSystem(db_instance);
+#ifdef DUCKDB_HAS_OPENER_FILESYSTEM
+	// v1.5.3+: DatabaseFileSystem (OpenerFileSystem) auto-injects the db-level opener
+	// and explicitly rejects a caller-supplied one.
+	return main_fs.OpenFile(s3_url, flags, nullptr);
+#else
+	// v1.4.x: no auto-injection; pass the opener so httpfs can read S3 credentials.
+	return main_fs.OpenFile(s3_url, flags, file_opener);
+#endif
+}
+
+S3RedirectFileHandle::BorrowedHandle S3RedirectFileHandle::BorrowHandle() {
+	{
+		std::lock_guard<std::mutex> lk(pool_mu);
+		if (!idle_pool.empty()) {
+			auto h = std::move(idle_pool.back());
+			idle_pool.pop_back();
+			return BorrowedHandle(*this, std::move(h));
+		}
+	}
+	// Pool empty: open a new handle without holding the lock (avoids blocking
+	// other threads returning handles while a HEAD/GET is in flight).
+	return BorrowedHandle(*this, OpenHandle());
+}
+
+void S3RedirectFileHandle::ReturnHandle(unique_ptr<FileHandle> h) {
+	std::lock_guard<std::mutex> lk(pool_mu);
+	idle_pool.push_back(std::move(h));
+}
+
+// ---------------------------------------------------------------------------
+// S3RedirectFileHandle — public interface
+// ---------------------------------------------------------------------------
+
 S3RedirectFileHandle::S3RedirectFileHandle(FileSystem &fs, DatabaseInstance &db, const string &url,
                                            idx_t content_length, timestamp_t last_modified,
                                            optional_ptr<FileOpener> opener)
     : FileHandle(fs, url, FileFlags::FILE_FLAGS_READ), s3_url(url), known_content_length(content_length),
-      last_modified_time(last_modified), db_instance(db) {
-	// Open eagerly so the handle is ready before any concurrent reader arrives.
-	// FILE_FLAGS_PARALLEL_ACCESS tells httpfs to bypass its shared rolling buffer and issue each
-	// positional read as an independent range GET (protected by hfh.mu post-request), making
-	// concurrent positional reads safe on this single handle.
-	//
-	// Opener handling differs by DuckDB version:
-	//   v1.5.3+  FileSystem::GetFileSystem(db) returns an OpenerFileSystem that auto-injects a
-	//            DatabaseFileOpener and explicitly rejects a caller-supplied opener — pass nullptr.
-	//   v1.4.x   No such wrapper; the opener must be passed explicitly to give httpfs access to
-	//            S3 credentials and HTTP settings.
-	auto &main_fs = FileSystem::GetFileSystem(db);
-#ifdef DUCKDB_HAS_OPENER_FILESYSTEM
-	s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS, nullptr);
-#else
-	s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
-#endif
+      last_modified_time(last_modified), db_instance(db), file_opener(opener) {
+	// Open the primary handle eagerly (sequential cursor / metadata ops).
+	// This also validates the S3 URL and credentials at open time rather than
+	// deferring errors to the first read.
+	primary_handle = OpenHandle();
 }
 
-FileHandle &S3RedirectFileHandle::GetS3Handle() {
-	D_ASSERT(s3_handle);
-	return *s3_handle;
+FileHandle &S3RedirectFileHandle::GetPrimaryHandle() {
+	D_ASSERT(primary_handle);
+	return *primary_handle;
 }
 
 idx_t S3RedirectFileHandle::GetFileSize() {
@@ -58,17 +88,28 @@ idx_t S3RedirectFileHandle::GetFileSize() {
 }
 
 void S3RedirectFileHandle::Close() {
-	if (s3_handle) {
-		s3_handle->Close();
+	if (primary_handle) {
+		primary_handle->Close();
 	}
+	std::lock_guard<std::mutex> lk(pool_mu);
+	for (auto &h : idle_pool) {
+		if (h) {
+			h->Close();
+		}
+	}
+	idle_pool.clear();
 }
 
+// Positional read: borrow an exclusive handle from the pool so no two threads
+// share any mutable handle state regardless of how the underlying httpfs is implemented.
 void S3RedirectFileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
-	return GetS3Handle().Read(buffer, nr_bytes, location);
+	auto borrowed = BorrowHandle();
+	borrowed.get().Read(buffer, nr_bytes, location);
 }
 
+// Sequential read: uses the primary handle (single-threaded sequential access path).
 int64_t S3RedirectFileHandle::Read(void *buffer, idx_t nr_bytes) {
-	return GetS3Handle().Read(buffer, nr_bytes);
+	return GetPrimaryHandle().Read(buffer, nr_bytes);
 }
 
 bool S3RedirectFileHandle::CanSeek() {
@@ -76,12 +117,13 @@ bool S3RedirectFileHandle::CanSeek() {
 }
 
 void S3RedirectFileHandle::Sync() {
-	if (s3_handle)
-		s3_handle->Sync();
+	if (primary_handle) {
+		primary_handle->Sync();
+	}
 }
 
 FileType S3RedirectFileHandle::GetType() {
-	return GetS3Handle().GetType();
+	return GetPrimaryHandle().GetType();
 }
 
 timestamp_t S3RedirectFileHandle::GetLastModifiedTime() {
@@ -89,16 +131,20 @@ timestamp_t S3RedirectFileHandle::GetLastModifiedTime() {
 }
 
 void S3RedirectFileHandle::Write(void *buffer, idx_t nr_bytes, idx_t location) {
-	GetS3Handle().Write(buffer, nr_bytes);
+	GetPrimaryHandle().Write(buffer, nr_bytes);
 }
 
 int64_t S3RedirectFileHandle::Write(void *buffer, idx_t nr_bytes) {
-	return GetS3Handle().Write(buffer, nr_bytes);
+	return GetPrimaryHandle().Write(buffer, nr_bytes);
 }
 
 void S3RedirectFileHandle::Truncate(int64_t new_size) {
-	return GetS3Handle().Truncate(new_size);
+	return GetPrimaryHandle().Truncate(new_size);
 }
+
+// ---------------------------------------------------------------------------
+// S3RedirectProtocolFileSystem
+// ---------------------------------------------------------------------------
 
 unique_ptr<FileHandle> S3RedirectProtocolFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                               optional_ptr<FileOpener> opener) {
@@ -134,26 +180,29 @@ bool S3RedirectProtocolFileSystem::CanHandleFile(const string &fpath) {
 #endif
 }
 
+// Positional read: delegates to S3RedirectFileHandle::Read(buf,n,loc) which
+// borrows an exclusive pool handle — no shared mutable state between callers.
 void S3RedirectProtocolFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
-	if (s3_handle) {
-		return s3_handle->GetS3Handle().Read(buffer, nr_bytes, location);
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->Read(buffer, nr_bytes, location);
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
 
+// Sequential read: uses the primary handle.
 int64_t S3RedirectProtocolFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
-	if (s3_handle) {
-		return s3_handle->GetS3Handle().Read(buffer, nr_bytes);
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->Read(buffer, nr_bytes);
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
 
 void S3RedirectProtocolFileSystem::Seek(FileHandle &handle, idx_t location) {
-	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
-	if (s3_handle) {
-		return s3_handle->GetS3Handle().Seek(location);
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->GetPrimaryHandle().Seek(location);
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
@@ -161,15 +210,15 @@ void S3RedirectProtocolFileSystem::Seek(FileHandle &handle, idx_t location) {
 idx_t S3RedirectProtocolFileSystem::SeekPosition(FileHandle &handle) {
 	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
 	if (h) {
-		return h->GetS3Handle().SeekPosition();
+		return h->GetPrimaryHandle().SeekPosition();
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
 
 int64_t S3RedirectProtocolFileSystem::GetFileSize(FileHandle &handle) {
-	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
-	if (s3_handle) {
-		return s3_handle->GetFileSize();
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->GetFileSize();
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
@@ -179,15 +228,15 @@ FileType S3RedirectProtocolFileSystem::GetFileType(FileHandle &handle) {
 }
 
 void S3RedirectProtocolFileSystem::FileSync(FileHandle &handle) {
-	if (auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle)) {
-		s3_handle->Sync();
+	if (auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle)) {
+		h->Sync();
 	}
 }
 
 timestamp_t S3RedirectProtocolFileSystem::GetLastModifiedTime(FileHandle &handle) {
-	auto s3_handle = dynamic_cast<S3RedirectFileHandle *>(&handle);
-	if (s3_handle) {
-		return s3_handle->GetLastModifiedTime();
+	auto *h = dynamic_cast<S3RedirectFileHandle *>(&handle);
+	if (h) {
+		return h->GetLastModifiedTime();
 	}
 	throw InternalException("Invalid handle type in S3RedirectProtocolFileSystem");
 }
@@ -195,6 +244,10 @@ timestamp_t S3RedirectProtocolFileSystem::GetLastModifiedTime(FileHandle &handle
 vector<OpenFileInfo> S3RedirectProtocolFileSystem::Glob(const string &path, FileOpener *opener) {
 	return LocalFileSystem().Glob(path, nullptr);
 }
+
+// ---------------------------------------------------------------------------
+// ConvertLocalPathToS3
+// ---------------------------------------------------------------------------
 
 S3RedirectInfo ConvertLocalPathToS3(const string &local_path) {
 #ifndef __linux__
@@ -251,6 +304,10 @@ S3RedirectInfo ConvertLocalPathToS3(const string &local_path) {
 	return info;
 #endif
 }
+
+// ---------------------------------------------------------------------------
+// Extension entry points
+// ---------------------------------------------------------------------------
 
 std::string CwiqduckExtension::Name() {
 	return "cwiqduck";

--- a/src/cwiqduck_extension.cpp
+++ b/src/cwiqduck_extension.cpp
@@ -4,6 +4,11 @@
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_opener.hpp"
+// v1.5.3+ wraps the db filesystem in OpenerFileSystem, which auto-injects the opener and
+// rejects an explicit one.  The header didn't exist before v1.5.3.
+#if __has_include("duckdb/common/opener_file_system.hpp")
+#define DUCKDB_HAS_OPENER_FILESYSTEM 1
+#endif
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -25,11 +30,22 @@ S3RedirectFileHandle::S3RedirectFileHandle(FileSystem &fs, DatabaseInstance &db,
                                            optional_ptr<FileOpener> opener)
     : FileHandle(fs, url, FileFlags::FILE_FLAGS_READ), s3_url(url), known_content_length(content_length),
       last_modified_time(last_modified), db_instance(db) {
-	// Open eagerly while opener is in scope (credentials are read at OpenFile time by httpfs).
-	// FILE_FLAGS_PARALLEL_ACCESS tells httpfs to bypass its shared rolling buffer and use per-range
-	// GET requests protected by hfh.mu, making concurrent positional reads safe on this handle.
+	// Open eagerly so the handle is ready before any concurrent reader arrives.
+	// FILE_FLAGS_PARALLEL_ACCESS tells httpfs to bypass its shared rolling buffer and issue each
+	// positional read as an independent range GET (protected by hfh.mu post-request), making
+	// concurrent positional reads safe on this single handle.
+	//
+	// Opener handling differs by DuckDB version:
+	//   v1.5.3+  FileSystem::GetFileSystem(db) returns an OpenerFileSystem that auto-injects a
+	//            DatabaseFileOpener and explicitly rejects a caller-supplied opener — pass nullptr.
+	//   v1.4.x   No such wrapper; the opener must be passed explicitly to give httpfs access to
+	//            S3 credentials and HTTP settings.
 	auto &main_fs = FileSystem::GetFileSystem(db);
+#ifdef DUCKDB_HAS_OPENER_FILESYSTEM
+	s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS, nullptr);
+#else
 	s3_handle = main_fs.OpenFile(s3_url, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+#endif
 }
 
 FileHandle &S3RedirectFileHandle::GetS3Handle() {

--- a/src/include/cwiqduck_extension.hpp
+++ b/src/include/cwiqduck_extension.hpp
@@ -2,6 +2,9 @@
 
 #include "duckdb.hpp"
 
+#include <mutex>
+#include <vector>
+
 #undef MoveFile
 #undef RemoveDirectory
 #undef CreateDirectory
@@ -28,11 +31,51 @@ private:
 	string s3_url;
 	idx_t known_content_length;
 	timestamp_t last_modified_time;
-	// Opened eagerly at construction time with FILE_FLAGS_PARALLEL_ACCESS so httpfs routes every
-	// positional Read through its per-handle mutex-protected range-request path (httpfs.cpp:372-383),
-	// making concurrent positional reads safe on this single handle.
-	unique_ptr<FileHandle> s3_handle;
 	DatabaseInstance &db_instance;
+	// Stored for v1.4.x where pool handles must be opened with an explicit opener.
+	// In v1.5.3+ (OpenerFileSystem) this is unused; the db-level opener is injected automatically.
+	optional_ptr<FileOpener> file_opener;
+
+	// Primary handle: sequential cursor (Seek / SeekPosition / Read(buf,n)).
+	// Never shared between threads.
+	unique_ptr<FileHandle> primary_handle;
+
+	// Pool of idle handles for concurrent positional reads.
+	// Each borrow gives one thread exclusive ownership of a handle; the lock is
+	// held only for the O(1) push/pop, never across any network I/O.
+	std::mutex pool_mu;
+	std::vector<unique_ptr<FileHandle>> idle_pool;
+
+	// Opens a fresh underlying httpfs handle with FILE_FLAGS_DIRECT_IO so every
+	// positional read becomes an independent range GET with no shared rolling buffer.
+	unique_ptr<FileHandle> OpenHandle() const;
+
+	// RAII borrow: returns the handle to idle_pool on destruction.
+	struct BorrowedHandle {
+		S3RedirectFileHandle *owner; // pointer (not ref) so the struct is movable
+		unique_ptr<FileHandle> handle;
+
+		BorrowedHandle() : owner(nullptr) {
+		}
+		BorrowedHandle(S3RedirectFileHandle &o, unique_ptr<FileHandle> h) : owner(&o), handle(std::move(h)) {
+		}
+		BorrowedHandle(BorrowedHandle &&o) noexcept : owner(o.owner), handle(std::move(o.handle)) {
+			o.owner = nullptr;
+		}
+		BorrowedHandle(const BorrowedHandle &) = delete;
+		BorrowedHandle &operator=(const BorrowedHandle &) = delete;
+		~BorrowedHandle() {
+			if (owner && handle) {
+				owner->ReturnHandle(std::move(handle));
+			}
+		}
+		FileHandle &get() {
+			return *handle;
+		}
+	};
+
+	BorrowedHandle BorrowHandle();
+	void ReturnHandle(unique_ptr<FileHandle> h);
 
 public:
 	S3RedirectFileHandle(FileSystem &fs, DatabaseInstance &db, const string &s3_url, idx_t content_length,
@@ -41,9 +84,12 @@ public:
 
 	void Close() override;
 
+	// Positional read: borrows an exclusive handle from the pool.
 	void Read(void *buffer, idx_t nr_bytes, idx_t location);
+	// Sequential read: uses the primary handle.
 	int64_t Read(void *buffer, idx_t nr_bytes);
-	FileHandle &GetS3Handle();
+
+	FileHandle &GetPrimaryHandle();
 	FileType GetType();
 	timestamp_t GetLastModifiedTime();
 	idx_t GetFileSize();

--- a/src/include/cwiqduck_extension.hpp
+++ b/src/include/cwiqduck_extension.hpp
@@ -28,16 +28,15 @@ private:
 	string s3_url;
 	idx_t known_content_length;
 	timestamp_t last_modified_time;
+	// Opened eagerly at construction time with FILE_FLAGS_PARALLEL_ACCESS so httpfs routes every
+	// positional Read through its per-handle mutex-protected range-request path (httpfs.cpp:372-383),
+	// making concurrent positional reads safe on this single handle.
 	unique_ptr<FileHandle> s3_handle;
-	optional_ptr<FileOpener> file_opener;
 	DatabaseInstance &db_instance;
 
 public:
 	S3RedirectFileHandle(FileSystem &fs, DatabaseInstance &db, const string &s3_url, idx_t content_length,
-	                     timestamp_t last_modified, optional_ptr<FileOpener> opener)
-	    : FileHandle(fs, s3_url, FileFlags::FILE_FLAGS_READ), s3_url(s3_url), known_content_length(content_length),
-	      last_modified_time(last_modified), file_opener(opener), db_instance(db) {
-	}
+	                     timestamp_t last_modified, optional_ptr<FileOpener> opener);
 	virtual ~S3RedirectFileHandle() {};
 
 	void Close() override;
@@ -79,6 +78,7 @@ public:
 		return false;
 	};
 	void Seek(FileHandle &handle, idx_t location) override;
+	idx_t SeekPosition(FileHandle &handle) override;
 	int64_t GetFileSize(FileHandle &handle) override;
 	FileType GetFileType(FileHandle &handle) override;
 	void FileSync(FileHandle &handle) override;


### PR DESCRIPTION
Under heavy use we discovered a race condition in the module, fixed by this PR.

Fix race condition by replacing lazy open with eager open and add FILE_FLAGS_PARALLEL_ACCESS so that httpfs uses parallel-safe mechanisms.